### PR TITLE
Specify minimum ruby

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 Metrics/AbcSize:
   Enabled: false
 Metrics/CyclomaticComplexity:

--- a/edits.gemspec
+++ b/edits.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = ">= 2.6"
 
   spec.add_development_dependency "benchmark-ips", "~> 2.8"
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
Specify 2.6 as the minimum ruby version